### PR TITLE
fix: fix release ci by removing mount point files

### DIFF
--- a/.github/workflows/scripts/free-disk-space.sh
+++ b/.github/workflows/scripts/free-disk-space.sh
@@ -9,14 +9,14 @@ set -e
 # /usr/local/share/boost:/host_boost
 
 echo "Disk space before cleanup:"
-df -h
+df -ah
 
-sudo rm -rf /host_dotnet
-sudo rm -rf /host_android
-sudo rm -rf /host_ghc
-sudo rm -rf /host_toolcache
-sudo rm -rf /host_ghcup
-sudo rm -rf /host_boost
+sudo rm -rf /host_dotnet/*
+sudo rm -rf /host_android/*
+sudo rm -rf /host_ghc/*
+sudo rm -rf /host_toolcache/*
+sudo rm -rf /host_ghcup/*
+sudo rm -rf /host_boost/*
 
 echo "Disk space after cleanup:"
-df -h
+df -ah


### PR DESCRIPTION
Release CI is failing to clear files due to how the volumes are mounted. 
This will delete the files in the bind mount rather than trying to delete the volume itself. 