### PR TITLE
fix: add no-color option and fix test summary output

### DIFF
--- a/.agent/agent-memory/LogParsingSkillAndBugFixes_temp.md
+++ b/.agent/agent-memory/LogParsingSkillAndBugFixes_temp.md
@@ -1,0 +1,18 @@
+# Temporary Progress Tracker: Log Parsing Skill and Bug Fixes
+
+This checklist tracks implementation progress.
+
+- [x] **Phase 1: Create Log Parsing Skill**
+  - [x] Implement `.agent/skills/parse-test-logs.sh` with robust jq parsing logic
+  - [x] Make the script executable
+  - [x] Verify its formatting against existing `/tmp/*_test.log` logs
+- [x] **Phase 2: Add No-Color Option**
+  - [x] Update `run_tests.sh` to support `--no-color` option and standard `NO_COLOR`
+  - [x] Update `.github/workflows/scripts/nix-run.sh` to keep `NO_COLOR` in Nix context and support `NO_COLOR`
+- [x] **Phase 3: Fix Test Summary Reporting**
+  - [x] Improve `process_test_results` in `run_tests.sh` to log package-level failures separately
+  - [x] Improve `display_summary` in `run_tests.sh` to read and print failed tests directly in the final summary footer
+- [x] **Phase 4: Verification & Validation**
+  - [x] Validate color suppression is functional on run_tests.sh
+  - [x] Verify compilation and run lint checks on updated shell scripts
+  - [x] Summarize the changes

--- a/.agent/skills/parse-test-logs.sh
+++ b/.agent/skills/parse-test-logs.sh
@@ -43,6 +43,11 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -f|--file)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: Option $1 requires an argument." >&2
+        show_help >&2
+        exit 1
+      fi
       LOG_FILE="$2"
       shift 2
       ;;
@@ -69,6 +74,13 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# Validate mutual exclusion
+if [ "$FAILED_ONLY" = true ] && [ "$PASSED_ONLY" = true ]; then
+  echo "Error: --failed-only and --passed-only options are mutually exclusive." >&2
+  show_help >&2
+  exit 1
+fi
 
 # Initialize color settings
 if [ "$NO_COLOR_OPTION" = true ] || [ -n "${NO_COLOR:-}" ]; then

--- a/.agent/skills/parse-test-logs.sh
+++ b/.agent/skills/parse-test-logs.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# Skill: parse-test-logs.sh
+# Description: Standard parser for gotestsum / go test -json output files.
+#              Extracts and formats passed/failed tests, packages, and elapsed times.
+# Usage: .agent/skills/parse-test-logs.sh [options]
+
+set -euo pipefail
+
+# Default options
+LOG_FILE=""
+NO_COLOR_OPTION=false
+FAILED_ONLY=false
+PASSED_ONLY=false
+
+show_help() {
+  cat <<EOF
+Usage: parse-test-logs.sh [options]
+
+Parses gotestsum JSON log files to generate a structured outcome report.
+
+Options:
+  -f, --file PATH         Direct path to the JSON log file to parse.
+                          If omitted, the newest log file matching /tmp/*_test.log is used.
+  --no-color              Disable colored output (respects standard NO_COLOR env var too).
+  --failed-only           Only display failed tests and packages.
+  --passed-only           Only display passed tests.
+  -h, --help              Show this help message and exit.
+
+Examples:
+  # Parse the newest test log file
+  $ .agent/skills/parse-test-logs.sh
+
+  # Parse a specific log file with color suppressed
+  $ .agent/skills/parse-test-logs.sh -f /tmp/my_test.log --no-color
+
+  # Show failures only
+  $ .agent/skills/parse-test-logs.sh --failed-only
+EOF
+}
+
+# Parse command line options
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--file)
+      LOG_FILE="$2"
+      shift 2
+      ;;
+    --no-color)
+      NO_COLOR_OPTION=true
+      shift
+      ;;
+    --failed-only)
+      FAILED_ONLY=true
+      shift
+      ;;
+    --passed-only)
+      PASSED_ONLY=true
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown option $1" >&2
+      show_help >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Initialize color settings
+if [ "$NO_COLOR_OPTION" = true ] || [ -n "${NO_COLOR:-}" ]; then
+  RED=""
+  GREEN=""
+  YELLOW=""
+  BLUE=""
+  NC=""
+  CHECK_MARK="✓"
+  CROSS_MARK="✗"
+else
+  RED='\033[1;31m'
+  GREEN='\033[1;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[1;34m'
+  NC='\033[0m'
+  CHECK_MARK='\033[1;32m✓\033[0m'
+  CROSS_MARK='\033[1;31m✗\033[0m'
+fi
+
+# Locate log file if not specified
+if [ -z "$LOG_FILE" ]; then
+  # Find newest file matching /tmp/*_test.log
+  # Avoid using ls in pipe where possible, but here we find newest by time
+  LOG_FILE=$(find /tmp -maxdepth 1 -name "*_test.log" -type f -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -n 1 | awk '{print $2}')
+fi
+
+if [ -z "$LOG_FILE" ] || [ ! -f "$LOG_FILE" ]; then
+  echo -e "${RED}[ERROR]${NC} No valid test log file found or specified." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo -e "${RED}[ERROR]${NC} jq command is required but not installed." >&2
+  exit 1
+fi
+
+echo -e "${BLUE}=== Parsing Test Log: $LOG_FILE ===${NC}"
+
+# Extract details from JSON
+passed_tests=$(jq -r '. | select(.Action == "pass") | select(.Test != null) | "\(.Test)\t\(.Elapsed)"' "$LOG_FILE" 2>/dev/null | sort -u || true)
+failed_tests=$(jq -r '. | select(.Action == "fail") | select(.Test != null) | "\(.Test)\t\(.Elapsed)"' "$LOG_FILE" 2>/dev/null | sort -u || true)
+failed_pkgs=$(jq -r '. | select(.Action == "fail") | select(.Test == null) | "\(.Package)\t\(.Elapsed)"' "$LOG_FILE" 2>/dev/null | sort -u || true)
+
+# Count summaries
+passed_count=0
+if [ -n "$passed_tests" ]; then
+  passed_count=$(echo "$passed_tests" | wc -l)
+fi
+
+failed_test_count=0
+if [ -n "$failed_tests" ]; then
+  failed_test_count=$(echo "$failed_tests" | wc -l)
+fi
+
+failed_pkg_count=0
+if [ -n "$failed_pkgs" ]; then
+  failed_pkg_count=$(echo "$failed_pkgs" | wc -l)
+fi
+
+total_failures=$((failed_test_count + failed_pkg_count))
+
+# Print PASSED section
+if [ "$FAILED_ONLY" = false ]; then
+  echo ""
+  echo -e "${GREEN}PASSED TESTS ($passed_count):${NC}"
+  if [ -n "$passed_tests" ]; then
+    while IFS=$'\t' read -r name elapsed; do
+      if [ -n "$name" ]; then
+        printf "  %b %s (%ss)\n" "${CHECK_MARK}" "$name" "$elapsed"
+      fi
+    done <<< "$passed_tests"
+  else
+    echo "  None"
+  fi
+fi
+
+# Print FAILED section
+if [ "$PASSED_ONLY" = false ]; then
+  echo ""
+  echo -e "${RED}FAILED ITEMS ($total_failures):${NC}"
+  
+  if [ "$failed_test_count" -gt 0 ]; then
+    echo -e "  ${YELLOW}Individual Tests:${NC}"
+    while IFS=$'\t' read -r name elapsed; do
+      if [ -n "$name" ]; then
+        printf "    %b %s (%ss)\n" "${CROSS_MARK}" "$name" "$elapsed"
+      fi
+    done <<< "$failed_tests"
+  fi
+
+  if [ "$failed_pkg_count" -gt 0 ]; then
+    echo -e "  ${YELLOW}Packages/Builds:${NC}"
+    while IFS=$'\t' read -r name elapsed; do
+      if [ -n "$name" ]; then
+        printf "    %b Package: %s (%ss)\n" "${CROSS_MARK}" "$name" "$elapsed"
+      fi
+    done <<< "$failed_pkgs"
+  fi
+
+  if [ "$total_failures" -eq 0 ]; then
+    echo "  None"
+  fi
+fi
+
+echo ""
+echo -e "${BLUE}=======================================${NC}"
+if [ "$total_failures" -gt 0 ]; then
+  echo -e "${RED}Overall Outcome: FAILED${NC}"
+  exit 1
+else
+  echo -e "${GREEN}Overall Outcome: SUCCESS${NC}"
+  exit 0
+fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,6 +89,7 @@ jobs:
           GITHUB_OWNER: rancher
           IDENTIFIER: ${{github.run_id}}
           ZONE: ${{secrets.ZONE}}
+          NO_COLOR: true
         run: |
           bash .github/workflows/scripts/nix-run.sh "bash ./run_tests.sh -s"
 

--- a/.github/workflows/scripts/nix-run.sh
+++ b/.github/workflows/scripts/nix-run.sh
@@ -2,11 +2,19 @@
 set -euo pipefail
 
 # Color definitions for logging
-RED='\033[1;31m'
-GREEN='\033[1;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[1;34m'
-NC='\033[0m' # No Color
+if [[ -n "${NO_COLOR:-}" ]]; then
+  RED=''
+  GREEN=''
+  YELLOW=''
+  BLUE=''
+  NC=''
+else
+  RED='\033[1;31m'
+  GREEN='\033[1;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[1;34m'
+  NC='\033[0m' # No Color
+fi
 
 log_info() {
   printf "%b[INFO] [nix-run]%b %s\n" "${BLUE}" "${NC}" "$*"
@@ -163,6 +171,7 @@ run_nix_command() {
     --keep IDENTIFIER \
     --keep ZONE \
     --keep ACME_SERVER_URL \
+    --keep NO_COLOR \
     --command bash -e .nix-script.sh || nix_status=$?
 
   if [[ "$nix_status" -ne 0 ]]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,5 +54,6 @@ jobs:
           GITHUB_OWNER: rancher
           IDENTIFIER: ${{github.run_id}}
           ZONE: ${{secrets.ZONE}}
+          NO_COLOR: true
         run: |
           bash .github/workflows/scripts/nix-run.sh "bash ./run_tests.sh -s"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,6 +22,7 @@ dry_run=false
 half_dry=false
 skip_relay=false
 inside_relay=false
+no_color=false
 
 # Track whether cleanup has run
 cleanup_has_run=false
@@ -35,6 +36,8 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[1;34m'
 NC='\033[0m' # No Color
+CHECK_MARK='\033[1;32m✓\033[0m'
+CROSS_MARK='\033[1;31m✗\033[0m'
 
 log_info() {
   printf "%b[INFO] [run_tests]%b %s\n" "${BLUE}" "${NC}" "$*"
@@ -123,6 +126,7 @@ Options:
   --half-dry      Run in half-dry mode (deploy relay VM, but skip RKE2 fixture)
   --skip-relay    Skip relay packaging and run tests directly on workstation
   --inside-relay  Indicate the script is running inside the testing runner
+  --no-color      Disable color output (respects standard NO_COLOR env var too)
 
 Notes:
   - Only one of -c, -t, -p, -f, -g, --build-only, or --lint-only can be used at a time
@@ -157,6 +161,7 @@ parse_options() {
           half-dry) half_dry=true ;;
           skip-relay) skip_relay=true ;;
           inside-relay) inside_relay=true ;;
+          no-color) no_color=true ;;
           help) display_usage; exit 0 ;;
           identifier)
             specific_identifier="${!OPTIND}"
@@ -355,6 +360,7 @@ find_test_dir() {
 process_test_results() {
   local log_file="/tmp/${IDENTIFIER}_test.log"
   local fail_file="/tmp/${IDENTIFIER}_failed_tests.txt"
+  local fail_pkg_file="/tmp/${IDENTIFIER}_failed_packages.txt"
 
   if [ ! -f "$log_file" ] || ! command -v jq >/dev/null 2>&1; then
     return 0
@@ -362,29 +368,46 @@ process_test_results() {
 
   log_info "=== Test Outcome Summary ==="
 
-  local passed failed
+  local passed failed_tests failed_packages
   passed="$(jq -r '. | select(.Action == "pass") | select(.Test != null).Test' "$log_file" 2>/dev/null | sort -u | grep -v '^[[:space:]]*$' || true)"
-  failed="$(jq -r '. | select(.Action == "fail") | select(.Test != null).Test' "$log_file" 2>/dev/null | sort -u | grep -v '^[[:space:]]*$' || true)"
+  failed_tests="$(jq -r '. | select(.Action == "fail") | select(.Test != null).Test' "$log_file" 2>/dev/null | sort -u | grep -v '^[[:space:]]*$' || true)"
+  failed_packages="$(jq -r '. | select(.Action == "fail") | select(.Test == null).Package' "$log_file" 2>/dev/null | sort -u | grep -v '^[[:space:]]*$' || true)"
 
   if [ -n "$passed" ]; then
     log_success "PASSED TESTS:"
     while IFS= read -r test_name; do
       if [ -n "$test_name" ]; then
-        echo -e "  \033[1;32m✓\033[0m $test_name"
+        printf "  %b %s\n" "${CHECK_MARK}" "$test_name"
       fi
     done <<< "$passed"
   fi
 
-  if [ -n "$failed" ]; then
-    log_error "FAILED TESTS:"
-    while IFS= read -r test_name; do
-      if [ -n "$test_name" ]; then
-        echo -e "  \033[1;31m✗\033[0m $test_name"
-      fi
-    done <<< "$failed"
-    echo "$failed" > "$fail_file"
+  if [ -n "$failed_tests" ] || [ -n "$failed_packages" ]; then
+    log_error "FAILED ITEMS:"
+    if [ -n "$failed_tests" ]; then
+      while IFS= read -r test_name; do
+        if [ -n "$test_name" ]; then
+          printf "  %b %s\n" "${CROSS_MARK}" "$test_name"
+        fi
+      done <<< "$failed_tests"
+      echo "$failed_tests" > "$fail_file"
+    else
+      rm -f "$fail_file"
+    fi
+
+    if [ -n "$failed_packages" ]; then
+      while IFS= read -r pkg_name; do
+        if [ -n "$pkg_name" ]; then
+          printf "  %b Package: %s\n" "${CROSS_MARK}" "$pkg_name"
+        fi
+      done <<< "$failed_packages"
+      echo "$failed_packages" > "$fail_pkg_file"
+    else
+      rm -f "$fail_pkg_file"
+    fi
   else
     rm -f "$fail_file"
+    rm -f "$fail_pkg_file"
   fi
 
   log_info "============================"
@@ -653,6 +676,27 @@ display_summary() {
   # Exit with appropriate code based on test results
   if [ "$TESTS_PASSED" = false ]; then
     log_error "Tests FAILED"
+
+    if [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ] || [ -f "/tmp/${IDENTIFIER}_failed_packages.txt" ]; then
+      log_error "Failed items:"
+      if [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ]; then
+        while IFS= read -r test_name; do
+          if [ -n "$test_name" ]; then
+            printf "  %b %s\n" "${CROSS_MARK}" "${test_name}"
+          fi
+        done < "/tmp/${IDENTIFIER}_failed_tests.txt"
+      fi
+      if [ -f "/tmp/${IDENTIFIER}_failed_packages.txt" ]; then
+        while IFS= read -r pkg_name; do
+          if [ -n "$pkg_name" ]; then
+            printf "  %b Package: %s\n" "${CROSS_MARK}" "${pkg_name}"
+          fi
+        done < "/tmp/${IDENTIFIER}_failed_packages.txt"
+      fi
+    else
+      log_error "No specific failed tests or packages logged, but the exit code was non-zero."
+    fi
+
     if [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ]; then
       log_error "Failed tests logged to: /tmp/${IDENTIFIER}_failed_tests.txt"
     fi
@@ -724,6 +768,17 @@ validate_examples() {
 main() {
   parse_options "$@"
   validate_options
+
+  # Handle no-color option and environment variable
+  if [ "$no_color" = true ] || [ -n "${NO_COLOR:-}" ]; then
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+    CHECK_MARK='✓'
+    CROSS_MARK='✗'
+  fi
 
   # Set trap to run cleanup on exit, error, interrupt, or termination
   trap run_cleanup EXIT ERR INT TERM


### PR DESCRIPTION
## Problem
- **Color Formatting in CI:** The test logs can be extremely hard to read when ANSI escape codes are rendered as plain text in non-interactive CI/CD contexts.
- **Incorrect Summary Outcomes:** If a package fails to compile, fails in `init`, or panics during `TestMain`, no individual test case fails. In this scenario, `process_test_results` silently ignores the error because it strictly filters for `.Test != null` events. The final outcome summary appears completely empty of failures despite the overall test suite exiting non-zero.

## Solution
1. **Added No-Color Support:**
   - Introduced the `--no-color` option and standard `NO_COLOR` environment variable checks to `run_tests.sh`.
   - Propagated `NO_COLOR` down to the Nix container setup inside `.github/workflows/scripts/nix-run.sh` by keeping it in the environment using `--keep NO_COLOR`.
2. **Fixed Outcome Summary:**
   - Updated `process_test_results` to separate individual test failures (`.Test != null`) and package-level/setup/compile failures (`.Test == null`).
   - Package-level failures are logged separately to `/tmp/${IDENTIFIER}_failed_packages.txt`.
   - Corrected `display_summary` to read those logged failures and output the specific list of failed tests and failed packages directly in the final `=== Test Summary ===` footer.
3. **New Agent Log Parsing Skill:**
   - Added `.agent/skills/parse-test-logs.sh` to quickly parse and summarize JSON test log outcomes for easier troubleshooting.

## Verification
- Validated that running `./run_tests.sh --lint-only --no-color` runs clean linting with color escape codes suppressed.
- Verified that parsing failed log files correctly prints out failures with check/cross marks corresponding to color choices.