### PR TITLE
chore: implement agentic system hooks and safety guardrails

### DIFF
--- a/.agent/hooks/block-rancher-git.js
+++ b/.agent/hooks/block-rancher-git.js
@@ -31,6 +31,30 @@ function main() {
     commandClean = next;
   }
 
+  // Check for unauthorized git commit or push operations
+  const isCommitOrPush = /\bgit\s+(commit|push)\b/.test(commandClean);
+  if (isCommitOrPush) {
+    const segments = command.split(/\s*(?:&&|;|\|\|)\s*/);
+    const hasUserApproval = segments.every(segment => {
+      const isSegmentCommitOrPush = /\bgit\s+(commit|push)\b/.test(segment);
+      if (!isSegmentCommitOrPush) return true;
+      const segmentClean = segment.trim();
+      return /^(?:[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|"[^"]*"|\S+)\s+)*APPROVED_BY_USER=1\b/.test(segmentClean);
+    });
+    if (!hasUserApproval) {
+      console.log(JSON.stringify({
+        decision: "deny",
+        reason: "Security Policy Violation: Automated git commits and pushes are strictly prohibited without manual developer review and sign-off.\n\n" +
+                "To proceed with a commit or push, you MUST:\n" +
+                "1. Invite the developer in the chat to review the unstaged changes in their IDE.\n" +
+                "2. Obtain their explicit manual approval to perform the commit or push.\n" +
+                "3. Prefix your git command with APPROVED_BY_USER=1 (e.g., `APPROVED_BY_USER=1 git commit -m ...` or `APPROVED_BY_USER=1 git push ...`).",
+        systemMessage: "🔒 Security Block: Unauthorized automated git commit/push detected. Explicit developer approval required."
+      }));
+      process.exit(0);
+    }
+  }
+
   // Check if it is a git command and performs a remote-interacting operation
   const isGitCmd = /^(?:sudo\s+)?git\b/.test(commandClean);
   const isRemoteOp = /\b(push|pull|fetch|clone|remote)\b/.test(commandClean);
@@ -39,7 +63,9 @@ function main() {
     const targetDir = tool_input.dir_path || cwd || process.cwd();
 
     // Check command string directly to catch inline URL references or remote additions
-    if (/rancher/i.test(command)) {
+    // Ignore false positives from the filename "block-rancher-git.js"
+    const hasRancherRef = /rancher/i.test(command.replace(/block-rancher-git\.js/g, ''));
+    if (hasRancherRef) {
       console.log(JSON.stringify({
         decision: "deny",
         reason: "Security Policy Violation: Git command contains references to Rancher remote/URLs, which is strictly blocked.",

--- a/.agent/hooks/enforce-planning.js
+++ b/.agent/hooks/enforce-planning.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+
+function main() {
+  let inputData;
+  try {
+    inputData = JSON.parse(fs.readFileSync(0, 'utf-8'));
+  } catch (err) {
+    console.error("Failed to parse stdin JSON:", err);
+    console.log(JSON.stringify({ decision: "allow" }));
+    process.exit(0);
+  }
+
+  const { tool_name, tool_input, cwd } = inputData;
+
+  // We only inspect write_file and replace
+  if (tool_name !== 'write_file' && tool_name !== 'replace') {
+    console.log(JSON.stringify({ decision: "allow" }));
+    process.exit(0);
+  }
+
+  const filePath = tool_input.file_path;
+  if (!filePath) {
+    console.log(JSON.stringify({ decision: "allow" }));
+    process.exit(0);
+  }
+
+  // Resolve absolute path to check if it's within .agent/, .gemini/, or .claude/
+  const resolvedPath = path.resolve(cwd || process.cwd(), filePath);
+  const relativePath = path.relative(cwd || process.cwd(), resolvedPath);
+  const relativePathNormalized = relativePath.replace(/\\/g, '/');
+
+  // If the file is inside the .agent, .gemini, or .claude directories, we always allow.
+  if (
+    relativePathNormalized.startsWith('.agent/') ||
+    relativePathNormalized.startsWith('.gemini/') ||
+    relativePathNormalized.startsWith('.claude/') ||
+    relativePathNormalized === 'AGENTS.md' ||
+    relativePathNormalized === 'GEMINI.md'
+  ) {
+    console.log(JSON.stringify({ decision: "allow" }));
+    process.exit(0);
+  }
+
+  // Check if there is an active/modified plan in git status
+  try {
+    const statusOutput = execSync('git status --porcelain', {
+      cwd: cwd || process.cwd(),
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).toString();
+
+    // Check if git status has any modified (M), added (A), or untracked (??) plan files in .agent/plans/
+    const hasActivePlan = statusOutput.split('\n').some(line => {
+      const trimmed = line.trim();
+      if (!trimmed.includes('.agent/plans/')) return false;
+      const status = line.substring(0, 2);
+      // Ensure the file is not deleted ('D') or ignored ('!')
+      return !status.includes('D') && !status.includes('!');
+    });
+
+    if (!hasActivePlan) {
+      console.log(JSON.stringify({
+        decision: "deny",
+        reason: "Security Policy Violation: Modifying source code is strictly prohibited without an active plan.\n\n" +
+                "In accordance with 'development-process.md', you MUST first create or update a unified plan in '.agent/plans/' before applying edits to source files.\n\n" +
+                "To proceed:\n" +
+                "1. Create or update a unified plan (e.g. '.agent/plans/MyTask.md') containing a high-level abstract (top half) and a step-by-step '## Implementation Checklist' (bottom half).\n" +
+                "2. Obtain developer approval for your plan.\n" +
+                "3. Once the plan file is created (and visible in `git status`), you will be allowed to modify source files.",
+        systemMessage: "🔒 Security Block: No active plan found. Please create/update a plan under .agent/plans/ first."
+      }));
+      process.exit(0);
+    }
+  } catch {
+    // If not in a git repo or git status fails, allow to avoid blocking environments where git is unavailable
+  }
+
+  console.log(JSON.stringify({ decision: "allow" }));
+  process.exit(0);
+}
+
+main();

--- a/.agent/hooks/startup-context.sh
+++ b/.agent/hooks/startup-context.sh
@@ -8,6 +8,17 @@ cat > /dev/null
 echo "Loading session-start workspace context..." >&2
 
 combined_context=""
+combined_context+=$'###############################################################################\n'
+combined_context+=$'#                           CRITICAL AGENT MANDATES                           #\n'
+combined_context+=$'#                                                                             #\n'
+combined_context+=$'# 1. YOU MUST FOLLOW THE DEVELOPMENT PROCESS IN \'development-process.md\'.     #\n'
+combined_context+=$'# 2. YOU MUST NEVER COMMIT OR PUSH WITHOUT EXPLICIT APPROVAL AND THE          #\n'
+combined_context+=$'#    \'APPROVED_BY_USER=1\' PREFIX.                                             #\n'
+combined_context+=$'# 3. FOR ALL TASKS, YOU MUST DEFINE A SEQUENTIAL IMPLEMENTATION CHECKLIST AT  #\n'
+combined_context+=$'#    THE BOTTOM OF YOUR PLAN IN \'.agent/plans/<PlanName>.md\'.                 #\n'
+combined_context+=$'#                                                                             #\n'
+combined_context+=$'# FAILURE TO COMPLY WILL TRIGGER SECURITY BLOCKS AND PROCESS TERMINATION.     #\n'
+combined_context+=$'###############################################################################\n\n'
 
 if [[ -f "AGENTS.md" ]]; then
   combined_context+=$'# Context from AGENTS.md\n\n'

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -26,6 +26,30 @@
             "description": "Prevents running git remote operations against rancher-owned remotes"
           }
         ]
+      },
+      {
+        "matcher": "write_file",
+        "hooks": [
+          {
+            "name": "enforce-planning-before-write",
+            "type": "command",
+            "command": "node .agent/hooks/enforce-planning.js",
+            "timeout": 5000,
+            "description": "Enforces that a plan/checklist must be created or modified before writing files"
+          }
+        ]
+      },
+      {
+        "matcher": "replace",
+        "hooks": [
+          {
+            "name": "enforce-planning-before-replace",
+            "type": "command",
+            "command": "node .agent/hooks/enforce-planning.js",
+            "timeout": 5000,
+            "description": "Enforces that a plan/checklist must be created or modified before replacing text in files"
+          }
+        ]
       }
     ]
   }

--- a/.github/workflows/scripts/lint-all.sh
+++ b/.github/workflows/scripts/lint-all.sh
@@ -42,7 +42,7 @@ while read -r file; do
       failed_shellcheck=true
     fi
   fi
-done <<<"$(grep -Rl -e '^#!' | grep -v '.terraform' | grep -v '.git')"
+done <<<"$(grep -Rl -e '^#!' | grep -v '.terraform' | grep -v '.git' | grep -v -e '\.js$' -e '\.md$')"
 
 if [ "$failed_shellcheck" = true ]; then
   echo "❌ Shellcheck failed"


### PR DESCRIPTION
### Goal
Establish hard programmatic tool-level safety hooks and guardrails to enforce manual developer review and sign-off before any git commit or git push, and to enforce that plans are defined in '.agent/plans/' before any edits to source files.

### Changes
* **Tool-Level Git Guardrail (`.agent/hooks/block-rancher-git.js`):** Intercepts and blocks automated `git commit` or `git push` unless prefixed with `APPROVED_BY_USER=1`.
* **Programmatic Planning Guardrail (`.agent/hooks/enforce-planning.js`):** Blocks file writes and text replacements on source files if no modified/untracked plan exists under `.agent/plans/`.
* **Startup Banner (`.agent/hooks/startup-context.sh`):** Added a prominent system mandates warning banner injected on session start.
* **Hook Registration (`.gemini/settings.json`):** Registered the planning hook for the `write_file` and `replace` tools.