### PR TITLE
fix: upgrade public modules and workflow actions

### DIFF
--- a/.agent/skills/update-action-versions.sh
+++ b/.agent/skills/update-action-versions.sh
@@ -171,15 +171,15 @@ update_workflow_releases() {
           # Read the immediately following line (the action declaration)
           getline
           
-          # Check if the next line is the expected "- uses: owner/repo@<sha>" format
-          if ($0 ~ "^[[:space:]]*- uses: " repo "@") {
-            # Find where "- uses: " starts to preserve the original indentation
-            idx = index($0, "- uses: ")
+          # Check if the next line is the expected "- uses: owner/repo@<sha>" or "uses: owner/repo@<sha>" format
+          if ($0 ~ "^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*" repo "@") {
+            # Find where "uses: " starts to preserve the original indentation
+            idx = index($0, "uses: ")
             indent = substr($0, 1, idx - 1)
             
             # Print the line updated with the new commit SHA and trailing tag comment
             # e.g., "      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2"
-            print indent "- uses: " repo "@" new_sha " # " new_tag
+            print indent "uses: " repo "@" new_sha " # " new_tag
           } else {
             # If the next line is not a "- uses:" line, print it unchanged
             print $0

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: 'Checkout'
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The FOSSA token is shared between all repos in Rancher's GH org.
       # It can be used directly and there is no need to request specific access to EIO.

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: 'Checkout'
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 'Run Static Analysis'
         shell: bash
         run: |
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: 'Checkout'
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 'Check commit message'
         shell: bash
         run: |
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: 'Checkout'
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 'Check commit signatures'
         shell: bash
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: 'Checkout'
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 'Free Disk Space'
         run: |
@@ -75,7 +75,7 @@ jobs:
 
       - name: 'Configure AWS Credentials'
         # https://github.com/aws-actions/configure-aws-credentials/releases
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{env.AWS_ROLE}}
           role-session-name: ${{github.run_id}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: 'Checkout'
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 'Free Disk Space'
         run: |
@@ -41,7 +41,7 @@ jobs:
 
       - name: 'Configure AWS Credentials'
         # https://github.com/aws-actions/configure-aws-credentials/releases
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{env.AWS_ROLE}}
           role-session-name: ${{github.run_id}}

--- a/.github/workflows/update-go-deps.yaml
+++ b/.github/workflows/update-go-deps.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout repository
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
         # https://github.com/actions/setup-go/releases

--- a/custom_words.txt
+++ b/custom_words.txt
@@ -1,5 +1,6 @@
 agentic
 authconfig
+hyphenless
 indirecting
 kubeconfig
 nutanix

--- a/main.tf
+++ b/main.tf
@@ -285,7 +285,7 @@ resource "random_uuid" "join_token" {
 module "download" {
   count   = local.download_mod
   source  = "rancher/rke2-download/github"
-  version = "1.0.2"
+  version = "v1.0.3"
   release = local.install_rke2_version
   path    = local.local_file_path
 }
@@ -301,7 +301,7 @@ resource "random_pet" "server" {
 module "project" {
   count                       = local.project_mod
   source                      = "rancher/access/aws"
-  version                     = "4.0.5"
+  version                     = "v4.0.6"
   vpc_use_strategy            = local.project_vpc_use_strategy
   vpc_name                    = local.project_vpc_name
   vpc_type                    = local.project_vpc_type
@@ -343,7 +343,7 @@ module "server" {
     data.aws_security_group.general_info,
   ]
   source                       = "rancher/server/aws"
-  version                      = "2.0.3"
+  version                      = "v2.0.4"
   image_use_strategy           = local.server_image_use_strategy
   image                        = local.server_image
   image_type                   = local.server_image_type
@@ -378,7 +378,7 @@ module "default_config" {
     module.server,
   ]
   source  = "rancher/rke2-config/local"
-  version = "1.0.3"
+  version = "v1.0.4"
   tls-san = distinct(compact([
     lower("${local.project_domain}.${local.project_domain_zone}"),
   ]))
@@ -405,7 +405,7 @@ module "install" {
     module.download,
   ]
   source                     = "rancher/rke2-install/null"
-  version                    = "1.3.4"
+  version                    = "v1.3.5"
   release                    = local.install_rke2_version
   rpm_channel                = local.install_rpm_channel
   local_file_path            = local.local_file_path

--- a/test/test_relay/main.tf
+++ b/test/test_relay/main.tf
@@ -52,7 +52,7 @@ resource "terraform_data" "create_data_local" {
 
 module "access" {
   source                     = "rancher/access/aws"
-  version                    = "4.0.5"
+  version                    = "v4.0.6"
   vpc_name                   = "${local.project_name}-vpc"
   vpc_type                   = "dualstack"
   vpc_public                 = true
@@ -67,7 +67,7 @@ module "runner" {
     module.access,
   ]
   source                     = "rancher/server/aws"
-  version                    = "2.0.4"
+  version                    = "v2.0.4"
   image_type                 = local.image
   server_name                = local.project_name
   server_type                = "xl"


### PR DESCRIPTION
## Description
This pull request performs a complete repository-wide upgrade of all public Terraform modules and GitHub Actions workflow versions to their latest stable releases. It also patches a bug in the automated actions-upgrade script.

### Key Changes
- **Terraform Modules Upgraded:**
  - `rancher/rke2-download/github` -> `v1.0.3`
  - `rancher/access/aws` -> `v4.0.6`
  - `rancher/server/aws` -> `v2.0.4`
  - `rancher/rke2-config/local` -> `v1.0.4`
  - `rancher/rke2-install/null` -> `v1.3.5`
- **GitHub Actions Upgraded:**
  - `actions/checkout` -> `v7.0.1`
  - `aws-actions/configure-aws-credentials` -> `v6.2.3`
- **Utility Script Patched:**
  - Fixed a regex pattern inside the `.agent/skills/update-action-versions.sh` script to correctly support hyphenless `uses:` block declarations, ensuring robust automated upgrades in the future.