### PR TITLE
fix: add review proxy workflow and resolve parallel test failures

### DIFF
--- a/.agent/plans/ReviewProxyWorkflow.md
+++ b/.agent/plans/ReviewProxyWorkflow.md
@@ -1,6 +1,6 @@
 # Plan: Review Proxy Workflow
 
-* **Executed Date:** pending
+* **Executed Date:** Monday, August 3, 2026
 * **Purpose:** Implement a GitHub Actions workflow that acts as an approval and merge proxy for PR reviewers (like the rancher-dev group) who only have Triage access. When they approve a PR, this workflow will validate their access level, proxy the approval using GITHUB_TOKEN (which has Write access), and enable auto-merge.
 * **Goals & Code Snippets:**
   - Create a new workflow file at `.github/workflows/proxy-approve-merge.yml`.
@@ -29,14 +29,14 @@
 - [x] Conduct a proactive code review of the modified file diff against `github-copilot-review.instructions.md` to guarantee exactly 0 findings.
 
 ### Phase 4: Staging Isolation & IDE Review (Gateway 2)
-- [ ] Isolate changes in the active workspace and keep them unstaged.
-- [ ] Solicit manual developer IDE review and obtain explicit approval in the chat.
+- [x] Isolate changes in the active workspace and keep them unstaged.
+- [x] Solicit manual developer IDE review and obtain explicit approval in the chat.
 
 ### Phase 5: Authorized Commit, Push & Draft PR (Gateway 3)
-- [ ] Stage and commit all changes using the authorized conventional prefix and `APPROVED_BY_USER=1`.
-- [ ] Push the branch `feature/review-proxy-workflow` to your origin fork.
-- [ ] Generate a Draft Pull Request on GitHub using `.agent/skills/create-pr.sh --draft`.
-- [ ] Solicit manual developer review of the draft PR on GitHub and obtain explicit approval to graduate.
+- [x] Stage and commit all changes using the authorized conventional prefix and `APPROVED_BY_USER=1`.
+- [x] Push the branch `feature/review-proxy-workflow` to your origin fork.
+- [x] Generate a Draft Pull Request on GitHub using `.agent/skills/create-pr.sh --draft`.
+- [x] Solicit manual developer review of the draft PR on GitHub and obtain explicit approval to graduate.
 
 ### Phase 6: PR Graduation
-- [ ] Graduate the draft PR to ready-for-review using `.agent/skills/create-pr.sh --ready`.
+- [x] Graduate the draft PR to ready-for-review using `.agent/skills/create-pr.sh --ready`.

--- a/.agent/plans/ReviewProxyWorkflow.md
+++ b/.agent/plans/ReviewProxyWorkflow.md
@@ -1,0 +1,42 @@
+# Plan: Review Proxy Workflow
+
+* **Executed Date:** pending
+* **Purpose:** Implement a GitHub Actions workflow that acts as an approval and merge proxy for PR reviewers (like the rancher-dev group) who only have Triage access. When they approve a PR, this workflow will validate their access level, proxy the approval using GITHUB_TOKEN (which has Write access), and enable auto-merge.
+* **Goals & Code Snippets:**
+  - Create a new workflow file at `.github/workflows/proxy-approve-merge.yml`.
+  - Trigger on `pull_request_review` with type `submitted`.
+  - Condition job execution on `github.event.review.state == 'approved'`.
+  - Validate reviewer association as `MEMBER` or `COLLABORATOR` (ensuring at least Triage access).
+  - Use GitHub CLI (`gh`) to proxy approve and enable auto-merge with GITHUB_TOKEN.
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Planning & Setup
+- [x] Align with upstream and checkout the `feature/review-proxy-workflow` branch.
+- [x] Document the plan in `.agent/plans/ReviewProxyWorkflow.md` (this file).
+- [x] Solicit developer approval for this plan.
+
+### Phase 2: Workflow Implementation (Act)
+- [x] Create `.github/workflows/proxy-approve-merge.yml` with the specified triggers, permissions, and job conditions.
+- [x] Implement Step 1: Validate User (check for `MEMBER` or `COLLABORATOR`).
+- [x] Implement Step 2: Checkout Code (using actions/checkout commit SHA).
+- [x] Implement Step 3: Proxy Approve & Merge (use `gh pr review --approve` and `gh pr merge --auto --squash` with GITHUB_TOKEN).
+
+### Phase 3: Surgical Verification & Quality Gate
+- [x] Run `actionlint` locally to verify workflow syntax correctness.
+- [x] Conduct a proactive code review of the modified file diff against `github-copilot-review.instructions.md` to guarantee exactly 0 findings.
+
+### Phase 4: Staging Isolation & IDE Review (Gateway 2)
+- [ ] Isolate changes in the active workspace and keep them unstaged.
+- [ ] Solicit manual developer IDE review and obtain explicit approval in the chat.
+
+### Phase 5: Authorized Commit, Push & Draft PR (Gateway 3)
+- [ ] Stage and commit all changes using the authorized conventional prefix and `APPROVED_BY_USER=1`.
+- [ ] Push the branch `feature/review-proxy-workflow` to your origin fork.
+- [ ] Generate a Draft Pull Request on GitHub using `.agent/skills/create-pr.sh --draft`.
+- [ ] Solicit manual developer review of the draft PR on GitHub and obtain explicit approval to graduate.
+
+### Phase 6: PR Graduation
+- [ ] Graduate the draft PR to ready-for-review using `.agent/skills/create-pr.sh --ready`.

--- a/.github/workflows/proxy-approve-merge.yml
+++ b/.github/workflows/proxy-approve-merge.yml
@@ -1,0 +1,41 @@
+name: review-proxy
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  proxy:
+    name: Proxy Approve and Merge
+    if: github.event.review.state == 'approved'
+    permissions:
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate User
+        run: |
+          ASSOCIATION="${{ github.event.review.author_association }}"
+          echo "Reviewer association is: $ASSOCIATION"
+          if [[ "$ASSOCIATION" != "MEMBER" && "$ASSOCIATION" != "COLLABORATOR" ]]; then
+            echo "Error: Only MEMBER or COLLABORATOR approvals are proxied."
+            exit 1
+          fi
+          echo "User is validated as a trusted author."
+
+      - name: Checkout Code
+        # https://github.com/actions/checkout/releases
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Proxy Approve & Merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          ACTOR="${{ github.event.review.user.login }}"
+          echo "Proxying approval for $PR_URL on behalf of @$ACTOR..."
+          gh pr review "$PR_URL" --approve --body "Official approval triggered by trusted reviewer @$ACTOR."
+          echo "Enabling auto-merge..."
+          gh pr merge "$PR_URL" --auto --squash

--- a/examples/ha/config_files/suse_prep.sh.tftpl
+++ b/examples/ha/config_files/suse_prep.sh.tftpl
@@ -60,3 +60,40 @@ EOT
   echo "Testing IPv6 DNS resolution:"
   dig AAAA google.com
 fi
+
+# Ensure sshd.service / ssh.service exist (handling socket-activated SLE Micro units to prevent remote-exec restart errors)
+if [ -d /run/systemd/system ] || [ -d /etc/systemd/system ]; then
+  if ! systemctl list-unit-files 2>/dev/null | grep -q "sshd.service"; then
+    echo "sshd.service not found. Creating a dummy sshd.service for compatibility..."
+    cat <<'EOF' > /etc/systemd/system/sshd.service
+[Unit]
+Description=Dummy SSHD Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+
+  if ! systemctl list-unit-files 2>/dev/null | grep -q "ssh.service"; then
+    echo "ssh.service not found. Creating a dummy ssh.service for compatibility..."
+    cat <<'EOF' > /etc/systemd/system/ssh.service
+[Unit]
+Description=Dummy SSH Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+fi

--- a/examples/one/sle-micro_prep.sh
+++ b/examples/one/sle-micro_prep.sh
@@ -23,6 +23,38 @@ zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.
 rpm --import https://rpm.rancher.io/public.key || true
 zypper --gpg-auto-import-keys --non-interactive refresh
 zypper --gpg-auto-import-keys --non-interactive install -y --force-resolution restorecond policycoreutils curl
+
+if ! systemctl list-unit-files 2>/dev/null | grep -q "sshd.service"; then
+  echo "sshd.service not found. Creating dummy..."
+  cat <<'SSHD_EOF' > /etc/systemd/system/sshd.service
+[Unit]
+Description=Dummy SSHD Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+SSHD_EOF
+fi
+
+if ! systemctl list-unit-files 2>/dev/null | grep -q "ssh.service"; then
+  echo "ssh.service not found. Creating dummy..."
+  cat <<'SSH_EOF' > /etc/systemd/system/ssh.service
+[Unit]
+Description=Dummy SSH Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+SSH_EOF
+fi
 EOF
 
 # Enable IP forwarding for Kubernetes/RKE2 routing

--- a/examples/one/sles_prep.sh
+++ b/examples/one/sles_prep.sh
@@ -53,3 +53,40 @@ EOT
   echo "Testing IPv6 DNS resolution:"
   dig AAAA google.com
 fi
+
+# Ensure sshd.service / ssh.service exist (handling socket-activated SLE Micro units to prevent remote-exec restart errors)
+if [ -d /run/systemd/system ] || [ -d /etc/systemd/system ]; then
+  if ! systemctl list-unit-files 2>/dev/null | grep -q "sshd.service"; then
+    echo "sshd.service not found. Creating a dummy sshd.service for compatibility..."
+    cat <<'EOF' > /etc/systemd/system/sshd.service
+[Unit]
+Description=Dummy SSHD Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+
+  if ! systemctl list-unit-files 2>/dev/null | grep -q "ssh.service"; then
+    echo "ssh.service not found. Creating a dummy ssh.service for compatibility..."
+    cat <<'EOF' > /etc/systemd/system/ssh.service
+[Unit]
+Description=Dummy SSH Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+fi

--- a/examples/prod/config_files/suse_prep.sh.tftpl
+++ b/examples/prod/config_files/suse_prep.sh.tftpl
@@ -60,3 +60,40 @@ EOT
   echo "Testing IPv6 DNS resolution:"
   dig AAAA google.com
 fi
+
+# Ensure sshd.service / ssh.service exist (handling socket-activated SLE Micro units to prevent remote-exec restart errors)
+if [ -d /run/systemd/system ] || [ -d /etc/systemd/system ]; then
+  if ! systemctl list-unit-files 2>/dev/null | grep -q "sshd.service"; then
+    echo "sshd.service not found. Creating a dummy sshd.service for compatibility..."
+    cat <<'EOF' > /etc/systemd/system/sshd.service
+[Unit]
+Description=Dummy SSHD Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+
+  if ! systemctl list-unit-files 2>/dev/null | grep -q "ssh.service"; then
+    echo "ssh.service not found. Creating a dummy ssh.service for compatibility..."
+    cat <<'EOF' > /etc/systemd/system/ssh.service
+[Unit]
+Description=Dummy SSH Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+fi

--- a/examples/splitrole/config_files/suse_prep.sh.tftpl
+++ b/examples/splitrole/config_files/suse_prep.sh.tftpl
@@ -60,3 +60,40 @@ EOT
   echo "Testing IPv6 DNS resolution:"
   dig AAAA google.com
 fi
+
+# Ensure sshd.service / ssh.service exist (handling socket-activated SLE Micro units to prevent remote-exec restart errors)
+if [ -d /run/systemd/system ] || [ -d /etc/systemd/system ]; then
+  if ! systemctl list-unit-files 2>/dev/null | grep -q "sshd.service"; then
+    echo "sshd.service not found. Creating a dummy sshd.service for compatibility..."
+    cat <<'EOF' > /etc/systemd/system/sshd.service
+[Unit]
+Description=Dummy SSHD Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+
+  if ! systemctl list-unit-files 2>/dev/null | grep -q "ssh.service"; then
+    echo "ssh.service not found. Creating a dummy ssh.service for compatibility..."
+    cat <<'EOF' > /etc/systemd/system/ssh.service
+[Unit]
+Description=Dummy SSH Service for SLE Micro compatibility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+fi

--- a/examples/splitrole/main.tf
+++ b/examples/splitrole/main.tf
@@ -368,6 +368,6 @@ module "deploy_other_nodes" {
   jitter_max     = 300 # 5 min
   deploy_trigger = "v0.0.0"
   environment_variables = { # env variables are inherited, but you can add more here
-    TF_PLUGIN_CACHE_DIR = "$HOME/.terraform.d/plugin-cache"
+    TF_PLUGIN_CACHE_DIR = "$HOME/${each.key}/plugin-cache"
   }
 }


### PR DESCRIPTION
## Description
This pull request introduces the "Review Proxy" GitHub Actions workflow and resolves critical test failures identified in the `test.log` during parallel test runs on the SLES/SLE Micro fixtures.

### Key Changes
- **Review Proxy Workflow Added:**
  - Created `.github/workflows/proxy-approve-merge.yml` to proxy PR approvals from reviewers with Triage access (such as `rancher-dev`) using GITHUB_TOKEN (Write access), and enabling native Auto-Merge to bypass manual merges.
- **Parallel Test Failures Resolved:**
  - **Isolated Plugin Cache:** Fixed `Inconsistent dependency lock file` and `text file busy` errors in `examples/splitrole/main.tf` by isolating the `TF_PLUGIN_CACHE_DIR` per node: `TF_PLUGIN_CACHE_DIR = "$HOME/${each.key}/plugin-cache"`.
  - **SLE Micro SSHD compatibility:** Added a lightweight, compliant dummy `sshd.service` and `ssh.service` creation step within SLES and SLE Micro prep scripts. This prevents remote-exec failures during SSH daemon restart operations on modern systemd-socket-activated SLE Micro 6.1 instances.
- **Project Plan Documented:**
  - Generated `.agent/plans/ReviewProxyWorkflow.md` tracking all implementation and verification checklists.