### PR TITLE
fix: support transactional-update in multi-linux prep script

### DIFF
--- a/.agent/plans/FixMultiLinuxTransactional.md
+++ b/.agent/plans/FixMultiLinuxTransactional.md
@@ -1,0 +1,22 @@
+# Plan: Fix Transactional Multi-Linux Manager Server Failures
+
+**Executed Date:** 2026-08-12
+**Purpose:** Resolve the failing test `suse-multi-linux-manager-server-5-canal-stable-one-rpm-ipv4` caused by a read-only root filesystem on transactional SUSE Multi-Linux Manager systems.
+**Goals & Code Snippets:**
+The test logs indicate that the node prep script fails with:
+`can't create transaction lock on /usr/lib/sysimage/rpm/.rpm.lock (Read-only file system)`
+and `Failed to import public key`.
+This is because `examples/one/multi-linux_prep.sh` executes raw `zypper` and `rpm` commands on a transactional operating system.
+We will modify `examples/one/multi-linux_prep.sh` to dynamically check if `transactional-update` is available:
+- If yes, execute the repository add, key-import, and package installation commands inside `transactional-update --non-interactive --continue shell <<EOF`, and schedule a reboot at the end of the script: `(sleep 2 ; reboot) &`.
+- If no, run the standard direct `zypper` and `rpm` commands as before.
+
+## Implementation Checklist
+- [x] Write this approved plan to `.agent/plans/FixMultiLinuxTransactional.md`.
+- [x] Update `examples/one/multi-linux_prep.sh` to dynamically detect transactional systems, run package commands inside `transactional-update`, and schedule a reboot at the end.
+- [x] Static Validation: Run `shellcheck examples/one/multi-linux_prep.sh`.
+- [x] Proactive Code Review: Ensure diff aligns with `github-copilot-review.instructions.md`.
+- [x] Upstream Sync & Staging Isolation: Ensure branch and changes are isolated.
+- [x] Developer IDE Review Gateway: Present the unstaged diff and commit message to the developer, and obtain explicit manual approval.
+- [x] Authorized Commit & Push: Commit and push the changes with the `APPROVED_BY_USER=1` prefix.
+- [x] PR Generation Gateway: Run `create-pr.sh --draft` to raise the draft pull request.

--- a/.agent/plans/FixMultiLinuxTransactional.md
+++ b/.agent/plans/FixMultiLinuxTransactional.md
@@ -20,3 +20,10 @@ We will modify `examples/one/multi-linux_prep.sh` to dynamically check if `trans
 - [x] Developer IDE Review Gateway: Present the unstaged diff and commit message to the developer, and obtain explicit manual approval.
 - [x] Authorized Commit & Push: Commit and push the changes with the `APPROVED_BY_USER=1` prefix.
 - [x] PR Generation Gateway: Run `create-pr.sh --draft` to raise the draft pull request.
+
+## PR Comments Resolution Checklist
+- [x] Address review comments in `examples/one/multi-linux_prep.sh` by adding `timeout` guards to the `zypper` commands in the transactional-update path.
+- [x] Verify the modified script using `shellcheck`.
+- [x] Present the new unstaged diff for developer IDE review and obtain explicit approval.
+- [x] Commit and push the fix with `APPROVED_BY_USER=1`.
+- [x] Resolve the comment thread on GitHub using `.agent/skills/resolve-pr-reviews.sh 288 --all`.

--- a/examples/one/multi-linux_prep.sh
+++ b/examples/one/multi-linux_prep.sh
@@ -20,8 +20,8 @@ zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.
 zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/distribution/leap/15.6/repo/non-oss/ repo-non-oss || true
 zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/repositories/security:/SELinux_legacy/15.5/security:SELinux_legacy.repo || true
 rpm --import https://rpm.rancher.io/public.key || true
-zypper --gpg-auto-import-keys --non-interactive refresh
-zypper --gpg-auto-import-keys --non-interactive install -n -y --force-resolution restorecond policycoreutils curl
+timeout 10m zypper --gpg-auto-import-keys --non-interactive refresh
+timeout 5m zypper --gpg-auto-import-keys --non-interactive install -n -y --force-resolution restorecond policycoreutils curl
 EOF
     IS_TRANSACTIONAL=true
   else

--- a/examples/one/multi-linux_prep.sh
+++ b/examples/one/multi-linux_prep.sh
@@ -8,16 +8,31 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
+# Detect if transactional-update is present
+IS_TRANSACTIONAL=false
+
 # shellcheck disable=SC2154
 if [ "rpm" = "${install_method}" ]; then
+  if command -v transactional-update >/dev/null 2>&1; then
+    echo "Transactional system detected. Using transactional-update..."
+    transactional-update --non-interactive --continue shell <<EOF
+zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/distribution/leap/15.6/repo/oss/ repo-oss || true
+zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/distribution/leap/15.6/repo/non-oss/ repo-non-oss || true
+zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/repositories/security:/SELinux_legacy/15.5/security:SELinux_legacy.repo || true
+rpm --import https://rpm.rancher.io/public.key || true
+zypper --gpg-auto-import-keys --non-interactive refresh
+zypper --gpg-auto-import-keys --non-interactive install -n -y --force-resolution restorecond policycoreutils curl
+EOF
+    IS_TRANSACTIONAL=true
+  else
+    zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/distribution/leap/15.6/repo/oss/ repo-oss || true
+    zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/distribution/leap/15.6/repo/non-oss/ repo-non-oss || true
+    zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/repositories/security:/SELinux_legacy/15.5/security:SELinux_legacy.repo || true
+    rpm --import https://rpm.rancher.io/public.key || true
 
-  zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/distribution/leap/15.6/repo/oss/ repo-oss || true
-  zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/distribution/leap/15.6/repo/non-oss/ repo-non-oss || true
-  zypper --gpg-auto-import-keys --non-interactive ar -f https://download.opensuse.org/repositories/security:/SELinux_legacy/15.5/security:SELinux_legacy.repo || true
-  rpm --import https://rpm.rancher.io/public.key || true
-
-  timeout 10m zypper --gpg-auto-import-keys --non-interactive refresh
-  timeout 5m zypper --gpg-auto-import-keys --non-interactive install -n -y --force-resolution restorecond policycoreutils curl
+    timeout 10m zypper --gpg-auto-import-keys --non-interactive refresh
+    timeout 5m zypper --gpg-auto-import-keys --non-interactive install -n -y --force-resolution restorecond policycoreutils curl
+  fi
 fi
 
 # shellcheck disable=SC2154
@@ -53,4 +68,10 @@ EOT
 
   echo "Testing IPv6 DNS resolution:"
   dig AAAA google.com
+fi
+
+if [ "$IS_TRANSACTIONAL" = "true" ]; then
+  echo "Rebooting in 2 seconds to apply transactional updates..."
+  ( sleep 2 ; reboot ) &
+  exit 0
 fi


### PR DESCRIPTION
Addresses the package installation failures on read-only transactional systems like the SUSE Multi-Linux Manager Server 5. This PR adds a dynamic check for 'transactional-update' to perform the zypper and rpm package installations in a transactional snapshot and reboots the node, ensuring complete compatibility with standard SLES, openSUSE, and RHEL-compatible non-transactional hosts.