### PR TITLE
fix: support NetworkManager and Wicked dynamically for SUSE IPv6

### DIFF
--- a/.agent/plans/FixSlesIPv6NetworkManager.md
+++ b/.agent/plans/FixSlesIPv6NetworkManager.md
@@ -1,0 +1,25 @@
+# Plan: Fix SLES 16 / SLE Micro 6.x IPv6 NetworkManager Configuration
+
+**Executed Date:** 2026-08-12
+**Purpose:** Resolve the failing IPv6 CI tests on SLES 16 (`sles-16-canal-stable-one-rpm-ipv6`) caused by missing Wicked/ifcfg networking directory structures on NetworkManager-based modern SUSE environments.
+**Goals & Code Snippets:**
+The test logs indicate that the node prep script fails with:
+`/home/tf-.../install_prep.sh: line 26: /etc/sysconfig/network/ifcfg-eth0: No such file or directory`
+This is because modern SLES 16 and transactional SLE Micro 6.x images have migrated to NetworkManager by default and do not contain the `/etc/sysconfig/network` directory.
+We will modify the IPv6 section of all SUSE-based prep scripts (`examples/one/sles_prep.sh`, `examples/one/multi-linux_prep.sh`, `examples/ha/config_files/suse_prep.sh.tftpl`, `examples/prod/config_files/suse_prep.sh.tftpl`, and `examples/splitrole/config_files/suse_prep.sh.tftpl`) to dynamically detect the network manager:
+- If NetworkManager is available (i.e. `nmcli` or `/etc/NetworkManager` exists), we write a clean `.nmconnection` file to `/etc/NetworkManager/system-connections/$DEVICE.nmconnection`, reload connections, and restart NetworkManager.
+- If Wicked is used, we fall back to the standard `/etc/sysconfig/network/ifcfg-eth0` configuration.
+
+## Implementation Checklist
+- [x] Write this approved plan to `.agent/plans/FixSlesIPv6NetworkManager.md`.
+- [x] Update `examples/one/sles_prep.sh` to dynamically detect and configure NetworkManager or Wicked for IPv6.
+- [x] Update `examples/one/multi-linux_prep.sh` to dynamically detect and configure NetworkManager or Wicked for IPv6.
+- [x] Update `examples/ha/config_files/suse_prep.sh.tftpl` to dynamically detect and configure NetworkManager or Wicked for IPv6.
+- [x] Update `examples/prod/config_files/suse_prep.sh.tftpl` to dynamically detect and configure NetworkManager or Wicked for IPv6.
+- [x] Update `examples/splitrole/config_files/suse_prep.sh.tftpl` to dynamically detect and configure NetworkManager or Wicked for IPv6.
+- [x] Static Validation: Run `shellcheck` on all modified shell scripts.
+- [x] Proactive Code Review: Ensure diff aligns with `github-copilot-review.instructions.md`.
+- [x] Upstream Sync & Staging Isolation: Ensure branch and changes are isolated.
+- [x] Developer IDE Review Gateway: Present the unstaged diff and commit message to the developer, and obtain explicit manual approval.
+- [x] Authorized Commit & Push: Commit and push the changes with the `APPROVED_BY_USER=1` prefix.
+- [x] PR Generation Gateway: Run `create-pr.sh --draft` to raise the draft pull request.

--- a/examples/ha/config_files/suse_prep.sh.tftpl
+++ b/examples/ha/config_files/suse_prep.sh.tftpl
@@ -27,10 +27,45 @@ fi
 
 # shellcheck disable=SC2154
 if [ "ipv6" = "${ip_family}" ]; then
-  IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
-  IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+  if command -v nmcli >/dev/null 2>&1 || [ -d /etc/NetworkManager ]; then
+    echo "NetworkManager detected. Configuring IPv6 for NetworkManager..."
+    DEVICE="$(ip -6 -o a show scope global | awk '{print $2}' | head -n1)"
+    [ -z "$DEVICE" ] && DEVICE="eth0"
+    IPV6="$(ip -6 a show "$DEVICE" | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
-  cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    # Write NetworkManager configuration
+    mkdir -p /etc/NetworkManager/system-connections
+    cat > "/etc/NetworkManager/system-connections/$DEVICE.nmconnection" << EOT
+[connection]
+id=$DEVICE
+type=ethernet
+interface-name=$DEVICE
+
+[ipv4]
+method=disabled
+
+[ipv6]
+addr-gen-mode=eui64
+addresses1=$IPV6/64,$IPV6_GW
+dns=2001:4860:4860::8888;2606:4700:4700::1111;
+method=manual
+never-default=false
+EOT
+    chmod 0600 "/etc/NetworkManager/system-connections/$DEVICE.nmconnection"
+
+    if command -v nmcli >/dev/null 2>&1; then
+      nmcli connection reload || true
+      nmcli connection up "$DEVICE" || true
+    fi
+    systemctl restart NetworkManager 2>/dev/null || true
+  else
+    echo "Wicked/sysconfig network manager detected. Configuring IPv6 for Wicked..."
+    IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+
+    mkdir -p /etc/sysconfig/network
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
@@ -38,21 +73,21 @@ PREFIXLEN='64'
 DHCLIENT6_MODE='info'
 EOT
 
-  [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
-  echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
+    [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
+    echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
 
-  CONFIG_FILE="/etc/sysconfig/network/config"
-  IPV6_DNS1="2001:4860:4860::8888"
-  IPV6_DNS2="2606:4700:4700::1111"
+    CONFIG_FILE="/etc/sysconfig/network/config"
+    IPV6_DNS1="2001:4860:4860::8888"
+    IPV6_DNS2="2606:4700:4700::1111"
 
+    sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
+    sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
 
-  sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
-  sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
+    grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
+    grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
 
-  grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
-  grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
-
-  netconfig update -f
+    netconfig update -f
+  fi
 
   echo "Updated /etc/resolv.conf:"
   cat /etc/resolv.conf

--- a/examples/one/multi-linux_prep.sh
+++ b/examples/one/multi-linux_prep.sh
@@ -22,10 +22,45 @@ fi
 
 # shellcheck disable=SC2154
 if [ "ipv6" = "${ip_family}" ]; then
-  IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
-  IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+  if command -v nmcli >/dev/null 2>&1 || [ -d /etc/NetworkManager ]; then
+    echo "NetworkManager detected. Configuring IPv6 for NetworkManager..."
+    DEVICE="$(ip -6 -o a show scope global | awk '{print $2}' | head -n1)"
+    [ -z "$DEVICE" ] && DEVICE="eth0"
+    IPV6="$(ip -6 a show "$DEVICE" | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
-  cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    # Write NetworkManager configuration
+    mkdir -p /etc/NetworkManager/system-connections
+    cat > "/etc/NetworkManager/system-connections/$DEVICE.nmconnection" << EOT
+[connection]
+id=$DEVICE
+type=ethernet
+interface-name=$DEVICE
+
+[ipv4]
+method=disabled
+
+[ipv6]
+addr-gen-mode=eui64
+addresses1=$IPV6/64,$IPV6_GW
+dns=2001:4860:4860::8888;2606:4700:4700::1111;
+method=manual
+never-default=false
+EOT
+    chmod 0600 "/etc/NetworkManager/system-connections/$DEVICE.nmconnection"
+
+    if command -v nmcli >/dev/null 2>&1; then
+      nmcli connection reload || true
+      nmcli connection up "$DEVICE" || true
+    fi
+    systemctl restart NetworkManager 2>/dev/null || true
+  else
+    echo "Wicked/sysconfig network manager detected. Configuring IPv6 for Wicked..."
+    IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+
+    mkdir -p /etc/sysconfig/network
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
@@ -33,20 +68,21 @@ PREFIXLEN='64'
 DHCLIENT6_MODE='info'
 EOT
 
-  [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
-  echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
+    [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
+    echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
 
-  CONFIG_FILE="/etc/sysconfig/network/config"
-  IPV6_DNS1="2001:4860:4860::8888"
-  IPV6_DNS2="2606:4700:4700::1111"
+    CONFIG_FILE="/etc/sysconfig/network/config"
+    IPV6_DNS1="2001:4860:4860::8888"
+    IPV6_DNS2="2606:4700:4700::1111"
 
-  sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
-  sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
+    sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
+    sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
 
-  grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
-  grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
+    grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
+    grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
 
-  netconfig update -f
+    netconfig update -f
+  fi
 
   echo "Updated /etc/resolv.conf:"
   cat /etc/resolv.conf

--- a/examples/one/sles_prep.sh
+++ b/examples/one/sles_prep.sh
@@ -20,10 +20,45 @@ fi
 
 # shellcheck disable=SC2154
 if [ "ipv6" = "${ip_family}" ]; then
-  IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
-  IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+  if command -v nmcli >/dev/null 2>&1 || [ -d /etc/NetworkManager ]; then
+    echo "NetworkManager detected. Configuring IPv6 for NetworkManager..."
+    DEVICE="$(ip -6 -o a show scope global | awk '{print $2}' | head -n1)"
+    [ -z "$DEVICE" ] && DEVICE="eth0"
+    IPV6="$(ip -6 a show "$DEVICE" | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
-  cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    # Write NetworkManager configuration
+    mkdir -p /etc/NetworkManager/system-connections
+    cat > "/etc/NetworkManager/system-connections/$DEVICE.nmconnection" << EOT
+[connection]
+id=$DEVICE
+type=ethernet
+interface-name=$DEVICE
+
+[ipv4]
+method=disabled
+
+[ipv6]
+addr-gen-mode=eui64
+addresses1=$IPV6/64,$IPV6_GW
+dns=2001:4860:4860::8888;2606:4700:4700::1111;
+method=manual
+never-default=false
+EOT
+    chmod 0600 "/etc/NetworkManager/system-connections/$DEVICE.nmconnection"
+
+    if command -v nmcli >/dev/null 2>&1; then
+      nmcli connection reload || true
+      nmcli connection up "$DEVICE" || true
+    fi
+    systemctl restart NetworkManager 2>/dev/null || true
+  else
+    echo "Wicked/sysconfig network manager detected. Configuring IPv6 for Wicked..."
+    IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+
+    mkdir -p /etc/sysconfig/network
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
@@ -31,21 +66,21 @@ PREFIXLEN='64'
 DHCLIENT6_MODE='info'
 EOT
 
-  [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
-  echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
+    [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
+    echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
 
-  CONFIG_FILE="/etc/sysconfig/network/config"
-  IPV6_DNS1="2001:4860:4860::8888"
-  IPV6_DNS2="2606:4700:4700::1111"
+    CONFIG_FILE="/etc/sysconfig/network/config"
+    IPV6_DNS1="2001:4860:4860::8888"
+    IPV6_DNS2="2606:4700:4700::1111"
 
+    sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
+    sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
 
-  sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
-  sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
+    grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
+    grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
 
-  grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
-  grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
-
-  netconfig update -f
+    netconfig update -f
+  fi
 
   echo "Updated /etc/resolv.conf:"
   cat /etc/resolv.conf

--- a/examples/prod/config_files/suse_prep.sh.tftpl
+++ b/examples/prod/config_files/suse_prep.sh.tftpl
@@ -27,10 +27,45 @@ fi
 
 # shellcheck disable=SC2154
 if [ "ipv6" = "${ip_family}" ]; then
-  IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
-  IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+  if command -v nmcli >/dev/null 2>&1 || [ -d /etc/NetworkManager ]; then
+    echo "NetworkManager detected. Configuring IPv6 for NetworkManager..."
+    DEVICE="$(ip -6 -o a show scope global | awk '{print $2}' | head -n1)"
+    [ -z "$DEVICE" ] && DEVICE="eth0"
+    IPV6="$(ip -6 a show "$DEVICE" | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
-  cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    # Write NetworkManager configuration
+    mkdir -p /etc/NetworkManager/system-connections
+    cat > "/etc/NetworkManager/system-connections/$DEVICE.nmconnection" << EOT
+[connection]
+id=$DEVICE
+type=ethernet
+interface-name=$DEVICE
+
+[ipv4]
+method=disabled
+
+[ipv6]
+addr-gen-mode=eui64
+addresses1=$IPV6/64,$IPV6_GW
+dns=2001:4860:4860::8888;2606:4700:4700::1111;
+method=manual
+never-default=false
+EOT
+    chmod 0600 "/etc/NetworkManager/system-connections/$DEVICE.nmconnection"
+
+    if command -v nmcli >/dev/null 2>&1; then
+      nmcli connection reload || true
+      nmcli connection up "$DEVICE" || true
+    fi
+    systemctl restart NetworkManager 2>/dev/null || true
+  else
+    echo "Wicked/sysconfig network manager detected. Configuring IPv6 for Wicked..."
+    IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+
+    mkdir -p /etc/sysconfig/network
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
@@ -38,21 +73,21 @@ PREFIXLEN='64'
 DHCLIENT6_MODE='info'
 EOT
 
-  [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
-  echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
+    [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
+    echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
 
-  CONFIG_FILE="/etc/sysconfig/network/config"
-  IPV6_DNS1="2001:4860:4860::8888"
-  IPV6_DNS2="2606:4700:4700::1111"
+    CONFIG_FILE="/etc/sysconfig/network/config"
+    IPV6_DNS1="2001:4860:4860::8888"
+    IPV6_DNS2="2606:4700:4700::1111"
 
+    sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
+    sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
 
-  sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
-  sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
+    grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
+    grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
 
-  grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
-  grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
-
-  netconfig update -f
+    netconfig update -f
+  fi
 
   echo "Updated /etc/resolv.conf:"
   cat /etc/resolv.conf

--- a/examples/splitrole/config_files/suse_prep.sh.tftpl
+++ b/examples/splitrole/config_files/suse_prep.sh.tftpl
@@ -27,10 +27,45 @@ fi
 
 # shellcheck disable=SC2154
 if [ "ipv6" = "${ip_family}" ]; then
-  IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
-  IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+  if command -v nmcli >/dev/null 2>&1 || [ -d /etc/NetworkManager ]; then
+    echo "NetworkManager detected. Configuring IPv6 for NetworkManager..."
+    DEVICE="$(ip -6 -o a show scope global | awk '{print $2}' | head -n1)"
+    [ -z "$DEVICE" ] && DEVICE="eth0"
+    IPV6="$(ip -6 a show "$DEVICE" | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
-  cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    # Write NetworkManager configuration
+    mkdir -p /etc/NetworkManager/system-connections
+    cat > "/etc/NetworkManager/system-connections/$DEVICE.nmconnection" << EOT
+[connection]
+id=$DEVICE
+type=ethernet
+interface-name=$DEVICE
+
+[ipv4]
+method=disabled
+
+[ipv6]
+addr-gen-mode=eui64
+addresses1=$IPV6/64,$IPV6_GW
+dns=2001:4860:4860::8888;2606:4700:4700::1111;
+method=manual
+never-default=false
+EOT
+    chmod 0600 "/etc/NetworkManager/system-connections/$DEVICE.nmconnection"
+
+    if command -v nmcli >/dev/null 2>&1; then
+      nmcli connection reload || true
+      nmcli connection up "$DEVICE" || true
+    fi
+    systemctl restart NetworkManager 2>/dev/null || true
+  else
+    echo "Wicked/sysconfig network manager detected. Configuring IPv6 for Wicked..."
+    IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
+    IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
+
+    mkdir -p /etc/sysconfig/network
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
@@ -38,21 +73,21 @@ PREFIXLEN='64'
 DHCLIENT6_MODE='info'
 EOT
 
-  [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
-  echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
+    [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
+    echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes
 
-  CONFIG_FILE="/etc/sysconfig/network/config"
-  IPV6_DNS1="2001:4860:4860::8888"
-  IPV6_DNS2="2606:4700:4700::1111"
+    CONFIG_FILE="/etc/sysconfig/network/config"
+    IPV6_DNS1="2001:4860:4860::8888"
+    IPV6_DNS2="2606:4700:4700::1111"
 
+    sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
+    sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
 
-  sed -i "s|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"|" "$CONFIG_FILE"
-  sed -i "s|^NETWORKMANAGER_DISABLE_IPV6=.*|NETWORKMANAGER_DISABLE_IPV6=\"no\"|" "$CONFIG_FILE"
+    grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
+    grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
 
-  grep -q "^NETCONFIG_DNS_STATIC_SERVERS=" "$CONFIG_FILE" || echo "NETCONFIG_DNS_STATIC_SERVERS=\"$IPV6_DNS1 $IPV6_DNS2\"" >> "$CONFIG_FILE"
-  grep -q "^NETWORKMANAGER_DISABLE_IPV6=" "$CONFIG_FILE" || echo "NETWORKMANAGER_DISABLE_IPV6=\"no\"" >> "$CONFIG_FILE"
-
-  netconfig update -f
+    netconfig update -f
+  fi
 
   echo "Updated /etc/resolv.conf:"
   cat /etc/resolv.conf


### PR DESCRIPTION
Resolves the IPv6 configuration failures on modern SLES 16 and transactional SLE Micro 6.x environments. On these systems, Wicked has been replaced by NetworkManager, which was causing Wicked-specific configuration file writes to fail because the '/etc/sysconfig/network' directory does not exist. This PR adds a dynamic check to autodetect whether NetworkManager or Wicked is active, and configures the IPv6 interface accordingly across SLES and Multi-Linux prep scripts.