### PR TITLE
fix: drop multi-linux server and make ipv6 dig fallback safe

### DIFF
--- a/.agent/plans/FixSlesIPv6DigNotFound.md
+++ b/.agent/plans/FixSlesIPv6DigNotFound.md
@@ -1,0 +1,32 @@
+# Plan: Fix Missing dig Command Failures on Minimal SUSE Images
+
+**Executed Date:** pending
+**Purpose:** Resolve the failing IPv6 CI tests on SLES 16/SLE Micro 6.x caused by the missing `dig` command on minimal/appliance-style SUSE environments.
+**Goals & Code Snippets:**
+The test logs indicate that the node prep script fails with:
+`install_prep.sh: line 89: dig: command not found`
+This is because modern minimal SLES 16 and transactional SLE Micro images do not pre-install the `bind-utils` package containing `dig`. Because `set -e` is active, the missing command crashes the entire provisioning script, failing the run.
+We will modify all 8 occurrences of `dig AAAA google.com` across all SUSE-based prep scripts (`examples/one/sles_prep.sh`, `examples/one/multi-linux_prep.sh`, `examples/ha/config_files/suse_prep.sh.tftpl`, `examples/ha/config_files/multi-linux_prep.sh.tftpl`, `examples/prod/config_files/suse_prep.sh.tftpl`, `examples/prod/config_files/multi-linux_prep.sh.tftpl`, `examples/splitrole/config_files/suse_prep.sh.tftpl`, and `examples/splitrole/config_files/multi-linux_prep.sh.tftpl`) to safely and non-fatally test DNS resolution:
+- If `dig` is available, run it.
+- If `dig` is not available, print a helpful warning message and exit cleanly without crashing the script.
+- We will also completely remove the `suse-multi-linux-manager-server-5` image from our Terraform variable definitions, test combinations, and test suites, as it is an appliance server and does not make sense to deploy RKE2 on.
+
+## Implementation Checklist
+- [x] Write this approved plan to `.agent/plans/FixSlesIPv6DigNotFound.md`.
+- [x] Remove `suse-multi-linux-manager-server-5` from `variables.tf` (description, allowed list, and validation blocks).
+- [x] Remove `suse-multi-linux-manager-server-5` from `test/fixtures/combinations.go`.
+- [x] Remove `suse-multi-linux-manager-server-5` from `test/ready_test.go`.
+- [x] Update `examples/one/sles_prep.sh` with safe `dig` check and `getent` fallback.
+- [x] Update `examples/one/multi-linux_prep.sh` with safe `dig` check and `getent` fallback.
+- [x] Update `examples/ha/config_files/suse_prep.sh.tftpl` with safe `dig` check and `getent` fallback.
+- [x] Update `examples/ha/config_files/multi-linux_prep.sh.tftpl` with safe `dig` check and `getent` fallback.
+- [x] Update `examples/prod/config_files/suse_prep.sh.tftpl` with safe `dig` check and `getent` fallback.
+- [x] Update `examples/prod/config_files/multi-linux_prep.sh.tftpl` with safe `dig` check and `getent` fallback.
+- [x] Update `examples/splitrole/config_files/suse_prep.sh.tftpl` with safe `dig` check and `getent` fallback.
+- [x] Update `examples/splitrole/config_files/multi-linux_prep.sh.tftpl` with safe `dig` check and `getent` fallback.
+- [x] Static Validation: Run `shellcheck` on all modified files.
+- [x] Proactive Code Review: Ensure diff aligns with `github-copilot-review.instructions.md`.
+- [x] Upstream Sync & Staging Isolation: Ensure branch and changes are isolated.
+- [ ] Developer IDE Review Gateway: Present the unstaged diff and commit message to the developer, and obtain explicit manual approval.
+- [ ] Authorized Commit & Push: Commit and push the changes with the `APPROVED_BY_USER=1` prefix.
+- [ ] PR Generation Gateway: Run `create-pr.sh --draft` to raise the draft pull request.

--- a/examples/ha/config_files/multi-linux_prep.sh.tftpl
+++ b/examples/ha/config_files/multi-linux_prep.sh.tftpl
@@ -54,5 +54,11 @@ EOT
   cat /etc/resolv.conf
 
   echo "Testing IPv6 DNS resolution:"
-  dig AAAA google.com
+  if command -v dig >/dev/null 2>&1; then
+    dig AAAA google.com
+  elif command -v getent >/dev/null 2>&1; then
+    getent hosts google.com
+  else
+    echo "Warning: Neither dig nor getent is available to test DNS resolution."
+  fi
 fi

--- a/examples/ha/config_files/suse_prep.sh.tftpl
+++ b/examples/ha/config_files/suse_prep.sh.tftpl
@@ -93,7 +93,13 @@ EOT
   cat /etc/resolv.conf
 
   echo "Testing IPv6 DNS resolution:"
-  dig AAAA google.com
+  if command -v dig >/dev/null 2>&1; then
+    dig AAAA google.com
+  elif command -v getent >/dev/null 2>&1; then
+    getent hosts google.com
+  else
+    echo "Warning: Neither dig nor getent is available to test DNS resolution."
+  fi
 fi
 
 # Ensure sshd.service / ssh.service exist (handling socket-activated SLE Micro units to prevent remote-exec restart errors)

--- a/examples/one/multi-linux_prep.sh
+++ b/examples/one/multi-linux_prep.sh
@@ -103,7 +103,13 @@ EOT
   cat /etc/resolv.conf
 
   echo "Testing IPv6 DNS resolution:"
-  dig AAAA google.com
+  if command -v dig >/dev/null 2>&1; then
+    dig AAAA google.com
+  elif command -v getent >/dev/null 2>&1; then
+    getent hosts google.com
+  else
+    echo "Warning: Neither dig nor getent is available to test DNS resolution."
+  fi
 fi
 
 if [ "$IS_TRANSACTIONAL" = "true" ]; then

--- a/examples/one/sles_prep.sh
+++ b/examples/one/sles_prep.sh
@@ -86,7 +86,13 @@ EOT
   cat /etc/resolv.conf
 
   echo "Testing IPv6 DNS resolution:"
-  dig AAAA google.com
+  if command -v dig >/dev/null 2>&1; then
+    dig AAAA google.com
+  elif command -v getent >/dev/null 2>&1; then
+    getent hosts google.com
+  else
+    echo "Warning: Neither dig nor getent is available to test DNS resolution."
+  fi
 fi
 
 # Ensure sshd.service / ssh.service exist (handling socket-activated SLE Micro units to prevent remote-exec restart errors)

--- a/examples/prod/config_files/multi-linux_prep.sh.tftpl
+++ b/examples/prod/config_files/multi-linux_prep.sh.tftpl
@@ -54,5 +54,11 @@ EOT
   cat /etc/resolv.conf
 
   echo "Testing IPv6 DNS resolution:"
-  dig AAAA google.com
+  if command -v dig >/dev/null 2>&1; then
+    dig AAAA google.com
+  elif command -v getent >/dev/null 2>&1; then
+    getent hosts google.com
+  else
+    echo "Warning: Neither dig nor getent is available to test DNS resolution."
+  fi
 fi

--- a/examples/prod/config_files/suse_prep.sh.tftpl
+++ b/examples/prod/config_files/suse_prep.sh.tftpl
@@ -93,7 +93,13 @@ EOT
   cat /etc/resolv.conf
 
   echo "Testing IPv6 DNS resolution:"
-  dig AAAA google.com
+  if command -v dig >/dev/null 2>&1; then
+    dig AAAA google.com
+  elif command -v getent >/dev/null 2>&1; then
+    getent hosts google.com
+  else
+    echo "Warning: Neither dig nor getent is available to test DNS resolution."
+  fi
 fi
 
 # Ensure sshd.service / ssh.service exist (handling socket-activated SLE Micro units to prevent remote-exec restart errors)

--- a/examples/splitrole/config_files/multi-linux_prep.sh.tftpl
+++ b/examples/splitrole/config_files/multi-linux_prep.sh.tftpl
@@ -54,5 +54,11 @@ EOT
   cat /etc/resolv.conf
 
   echo "Testing IPv6 DNS resolution:"
-  dig AAAA google.com
+  if command -v dig >/dev/null 2>&1; then
+    dig AAAA google.com
+  elif command -v getent >/dev/null 2>&1; then
+    getent hosts google.com
+  else
+    echo "Warning: Neither dig nor getent is available to test DNS resolution."
+  fi
 fi

--- a/examples/splitrole/config_files/suse_prep.sh.tftpl
+++ b/examples/splitrole/config_files/suse_prep.sh.tftpl
@@ -93,7 +93,13 @@ EOT
   cat /etc/resolv.conf
 
   echo "Testing IPv6 DNS resolution:"
-  dig AAAA google.com
+  if command -v dig >/dev/null 2>&1; then
+    dig AAAA google.com
+  elif command -v getent >/dev/null 2>&1; then
+    getent hosts google.com
+  else
+    echo "Warning: Neither dig nor getent is available to test DNS resolution."
+  fi
 fi
 
 # Ensure sshd.service / ssh.service exist (handling socket-activated SLE Micro units to prevent remote-exec restart errors)

--- a/test/fixtures/combinations.go
+++ b/test/fixtures/combinations.go
@@ -105,7 +105,6 @@ func getData(t *testing.T) (map[string][]string, []string, error) {
 		"ubuntu-24",
 		"rocky-9",
 		"rhel-9",
-		"suse-multi-linux-manager-server-5",
 	}
 	ipFamilies := []string{"ipv4", "ipv6", "dualstack"}
 	t.Log("Getting releases")

--- a/test/ready_test.go
+++ b/test/ready_test.go
@@ -32,7 +32,6 @@ func TestMatrix(t *testing.T) {
 	suseTests := []string{
 		"sle-micro-61-canal-stable-one-rpm-ipv4",
 		"sles-16-canal-stable-one-rpm-ipv4",
-		"suse-multi-linux-manager-server-5-canal-stable-one-rpm-ipv4", // moved from extendedTests
 	}
 
 	ibmTests := []string{

--- a/variables.tf
+++ b/variables.tf
@@ -457,7 +457,6 @@ variable "server_image_type" {
       "ubuntu-24",
       "rocky-9",
       "rhel-9",
-      "suse-multi-linux-manager-server-5",
   EOT
   validation {
     condition = (
@@ -473,7 +472,6 @@ variable "server_image_type" {
         "ubuntu-24",
         "rocky-9",
         "rhel-9",
-        "suse-multi-linux-manager-server-5",
       ], var.server_image_type)
     )
     error_message = <<-EOT
@@ -489,7 +487,6 @@ variable "server_image_type" {
       "ubuntu-24",
       "rocky-9",
       "rhel-9",
-      "suse-multi-linux-manager-server-5",
     EOT
   }
   default = "sle-micro-61"


### PR DESCRIPTION
Resolves IPv6 DNS resolution testing crashes on minimal SLES 16/SLE Micro 6.x images where 'dig' is not pre-installed. It dynamically checks for 'dig' and safely falls back to standard POSIX-compliant 'getent hosts' if it is missing across all 8 SUSE-based prep scripts. In addition, this PR completely removes the defunct 'suse-multi-linux-manager-server-5' image option from variables.tf, Go test combinations, and test suites, as it is a management appliance and doesn't run RKE2.