### PR TITLE
fix: resolve nested heredoc keyword collisions across all prep scripts

### DIFF
--- a/.agent/plans/FixNestedHeredocEOF.md
+++ b/.agent/plans/FixNestedHeredocEOF.md
@@ -1,0 +1,29 @@
+# Plan: Fix Nested Heredoc Keyword Collision in Prep Scripts
+
+**Executed Date:** pending
+**Purpose:** Resolve the nested heredoc parsing failure inside HA, Splitrole, and Prod layout deployments caused by `EOT` keyword overlap between the outer `inputs` variable definition and inner script NetworkManager configuration blocks.
+**Goals & Code Snippets:**
+The test logs indicate that during `deploy_initial_node` execution, Terraform apply fails with:
+`Error: Invalid multi-line string` and `Error: Argument or block definition required`.
+This is because in `examples/ha/main.tf`, `examples/prod/main.tf`, and `examples/splitrole/main.tf`, the `inputs` variable is defined as a heredoc with an `EOT` marker:
+`inputs = <<-EOT ... EOT`
+Inside this heredoc, we interpolate `${local.install_prep_script}`.
+The OS prep scripts contain inner `cat > ... << EOT ... EOT` blocks (specifically for Wicked and `rke2-canal.conf` network configs). Because the inner heredoc uses the SAME `EOT` marker as the outer block, Terraform's HCL parser prematurely terminates the outer `inputs` heredoc, leading to invalid syntax and crashes.
+We will modify the inner heredoc marker from `EOT` to `EOF` across all affected OS prep scripts:
+- SUSE/SLES (`suse_prep.sh.tftpl`, `sles_prep.sh`)
+- Multi-Linux (`multi-linux_prep.sh.tftpl`, `multi-linux_prep.sh`)
+- RHEL/Rocky (`rhel_prep.sh.tftpl`, `rhel_prep.sh`)
+Since `EOF` is not used by any outer HCL heredoc block, this eliminates the keyword collision and resolves the parsing crashes. We have also confirmed that there are no unsafe `${...}` interpolations in these files.
+
+## Implementation Checklist
+- [x] Write this approved plan to `.agent/plans/FixNestedHeredocEOF.md`.
+- [x] Update SLES prep scripts (`examples/one/sles_prep.sh`, `examples/ha/config_files/suse_prep.sh.tftpl`, `examples/prod/config_files/suse_prep.sh.tftpl`, `examples/splitrole/config_files/suse_prep.sh.tftpl`) to use `EOF` instead of `EOT`.
+- [x] Update Multi-Linux prep scripts (`examples/one/multi-linux_prep.sh`, `examples/ha/config_files/multi-linux_prep.sh.tftpl`, `examples/prod/config_files/multi-linux_prep.sh.tftpl`, `examples/splitrole/config_files/multi-linux_prep.sh.tftpl`) to use `EOF` instead of `EOT`.
+- [x] Update RHEL prep scripts (`examples/one/rhel_prep.sh`, `examples/ha/config_files/rhel_prep.sh.tftpl`, `examples/prod/config_files/rhel_prep.sh.tftpl`, `examples/splitrole/config_files/rhel_prep.sh.tftpl`) to use `EOF` instead of `EOT`.
+- [x] Static Validation: Run `shellcheck` on all modified files.
+- [x] Proactive Code Review: Ensure diff aligns with `github-copilot-review.instructions.md`.
+- [x] Upstream Sync & Staging Isolation: Execute git-sync and branch isolation.
+- [x] Developer IDE Review Gateway: Present the unstaged diff and commit message to the developer, and obtain explicit manual approval.
+- [x] Authorized Commit & Push: Commit and push the changes with the `APPROVED_BY_USER=1` prefix.
+- [x] PR Generation Gateway: Run `create-pr.sh --draft` to raise the draft pull request.
+equest.

--- a/examples/ha/config_files/multi-linux_prep.sh.tftpl
+++ b/examples/ha/config_files/multi-linux_prep.sh.tftpl
@@ -27,13 +27,13 @@ if [ "ipv6" = "${ip_family}" ]; then
   IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
   IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
-  cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+  cat > /etc/sysconfig/network/ifcfg-eth0 << EOF
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
 PREFIXLEN='64'
 DHCLIENT6_MODE='info'
-EOT
+EOF
 
   [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
   echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes

--- a/examples/ha/config_files/rhel_prep.sh.tftpl
+++ b/examples/ha/config_files/rhel_prep.sh.tftpl
@@ -33,10 +33,10 @@ if [ "cis-rhel-8" = "${image}" ]; then
   systemctl disable nftables
 
   install -d /etc/NetworkManager/conf.d
-  cat > /etc/NetworkManager/conf.d/rke2-canal.conf << EOT
+  cat > /etc/NetworkManager/conf.d/rke2-canal.conf << EOF
 [keyfile]
 unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
-EOT
+EOF
 
   groupadd --system etcd && sudo useradd -s /sbin/nologin --system -g etcd etcd
 

--- a/examples/ha/config_files/suse_prep.sh.tftpl
+++ b/examples/ha/config_files/suse_prep.sh.tftpl
@@ -65,13 +65,13 @@ EOF
     IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
     mkdir -p /etc/sysconfig/network
-    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOF
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
 PREFIXLEN='64'
 DHCLIENT6_MODE='info'
-EOT
+EOF
 
     [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
     echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes

--- a/examples/one/multi-linux_prep.sh
+++ b/examples/one/multi-linux_prep.sh
@@ -75,13 +75,13 @@ EOF
     IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
     mkdir -p /etc/sysconfig/network
-    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOF
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
 PREFIXLEN='64'
 DHCLIENT6_MODE='info'
-EOT
+EOF
 
     [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
     echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes

--- a/examples/one/rhel_prep.sh
+++ b/examples/one/rhel_prep.sh
@@ -31,10 +31,10 @@ if [ "cis-rhel-8" = "${image}" ] || [ "cis-rhel-9" = "${image}" ]; then
   systemctl disable nftables
 
   install -d /etc/NetworkManager/conf.d
-  cat > /etc/NetworkManager/conf.d/rke2-canal.conf << EOT
+  cat > /etc/NetworkManager/conf.d/rke2-canal.conf << EOF
 [keyfile]
 unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
-EOT
+EOF
 
   groupadd --system etcd && sudo useradd -s /sbin/nologin --system -g etcd etcd
 

--- a/examples/one/sles_prep.sh
+++ b/examples/one/sles_prep.sh
@@ -58,13 +58,13 @@ EOF
     IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
     mkdir -p /etc/sysconfig/network
-    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOF
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
 PREFIXLEN='64'
 DHCLIENT6_MODE='info'
-EOT
+EOF
 
     [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
     echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes

--- a/examples/prod/config_files/multi-linux_prep.sh.tftpl
+++ b/examples/prod/config_files/multi-linux_prep.sh.tftpl
@@ -27,13 +27,13 @@ if [ "ipv6" = "${ip_family}" ]; then
   IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
   IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
-  cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+  cat > /etc/sysconfig/network/ifcfg-eth0 << EOF
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
 PREFIXLEN='64'
 DHCLIENT6_MODE='info'
-EOT
+EOF
 
   [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
   echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes

--- a/examples/prod/config_files/rhel_prep.sh.tftpl
+++ b/examples/prod/config_files/rhel_prep.sh.tftpl
@@ -33,10 +33,10 @@ if [ "cis-rhel-8" = "${image}" ]; then
   systemctl disable nftables
 
   install -d /etc/NetworkManager/conf.d
-  cat > /etc/NetworkManager/conf.d/rke2-canal.conf << EOT
+  cat > /etc/NetworkManager/conf.d/rke2-canal.conf << EOF
 [keyfile]
 unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
-EOT
+EOF
 
   groupadd --system etcd && sudo useradd -s /sbin/nologin --system -g etcd etcd
 

--- a/examples/prod/config_files/suse_prep.sh.tftpl
+++ b/examples/prod/config_files/suse_prep.sh.tftpl
@@ -65,13 +65,13 @@ EOF
     IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
     mkdir -p /etc/sysconfig/network
-    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOF
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
 PREFIXLEN='64'
 DHCLIENT6_MODE='info'
-EOT
+EOF
 
     [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
     echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes

--- a/examples/splitrole/config_files/multi-linux_prep.sh.tftpl
+++ b/examples/splitrole/config_files/multi-linux_prep.sh.tftpl
@@ -27,13 +27,13 @@ if [ "ipv6" = "${ip_family}" ]; then
   IPV6="$(ip -6 a show eth0 | grep inet6 | head -n1 | awk '{ print $2 }' | awk -F/ '{ print $1 }')"
   IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
-  cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+  cat > /etc/sysconfig/network/ifcfg-eth0 << EOF
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
 PREFIXLEN='64'
 DHCLIENT6_MODE='info'
-EOT
+EOF
 
   [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
   echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes

--- a/examples/splitrole/config_files/rhel_prep.sh.tftpl
+++ b/examples/splitrole/config_files/rhel_prep.sh.tftpl
@@ -33,10 +33,10 @@ if [ "cis-rhel-8" = "${image}" ]; then
   systemctl disable nftables
 
   install -d /etc/NetworkManager/conf.d
-  cat > /etc/NetworkManager/conf.d/rke2-canal.conf << EOT
+  cat > /etc/NetworkManager/conf.d/rke2-canal.conf << EOF
 [keyfile]
 unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
-EOT
+EOF
 
   groupadd --system etcd && sudo useradd -s /sbin/nologin --system -g etcd etcd
 

--- a/examples/splitrole/config_files/suse_prep.sh.tftpl
+++ b/examples/splitrole/config_files/suse_prep.sh.tftpl
@@ -65,13 +65,13 @@ EOF
     IPV6_GW="$(echo "$IPV6" | awk -F: '{gw=$1":"$2":"$3":"$4"::1"; print gw}')"
 
     mkdir -p /etc/sysconfig/network
-    cat > /etc/sysconfig/network/ifcfg-eth0 << EOT
+    cat > /etc/sysconfig/network/ifcfg-eth0 << EOF
 STARTMODE='auto'
 BOOTPROTO='static'
 IPADDR="$IPV6"
 PREFIXLEN='64'
 DHCLIENT6_MODE='info'
-EOT
+EOF
 
     [ ! -f /etc/sysconfig/network/routes ] && touch /etc/sysconfig/network/routes
     echo "default $IPV6_GW - -" >> /etc/sysconfig/network/routes


### PR DESCRIPTION
Resolve the nested heredoc parsing failure inside HA, Splitrole, and Prod layout deployments caused by `EOT` keyword overlap between the outer `inputs` variable definition and inner script NetworkManager/Wicked configuration blocks.

- Globally replaced inner `EOT` heredocs with `EOF` across SLES, Multi-Linux, and RHEL prep scripts and templates.
- Verified that all bash variables using `${}` are safe.
- Completed static syntax checks (`shellcheck`).